### PR TITLE
Add mime-type field to upload_file.py

### DIFF
--- a/rocketchat/api.py
+++ b/rocketchat/api.py
@@ -75,7 +75,7 @@ class RocketChatAPI(object):
             **kwargs
         )
 
-    def upload_file(self, room_id, description, file, message, **kwargs):
+    def upload_file(self, room_id, description, file, message, mime_type='text/plain', **kwargs):
         """
         Upload file to room
         :param room_id:
@@ -89,6 +89,7 @@ class RocketChatAPI(object):
             description=description,
             file=file,
             message=message,
+            mime_type=mime_type,
             **kwargs
         )
 

--- a/rocketchat/calls/groups/upload_file.py
+++ b/rocketchat/calls/groups/upload_file.py
@@ -12,7 +12,7 @@ class UploadFile(PostMixin, RocketChatBase):
                                              room_id=kwargs.get('room_id'))
 
     def build_files(self, **kwargs):
-        return {'file': open(kwargs.get('file'), 'rb')}
+        return {'file': (kwargs.get('file'), open(kwargs.get('file'), 'rb'), kwargs.get('mime_type'))}
 
     def build_payload(self, **kwargs):
         return {'description': kwargs.get('description'), 'msg': kwargs.get('message')}


### PR DESCRIPTION
Cause rocketchat can't understand type of file by default,
it will be uploaded as text with additional filename extension .txt
To preview your image in chat you should also give rocketchat mime-type