### PR TITLE
Add user token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,15 @@ Python API wrapper for the [Rocket chat API](https://rocket.chat/docs/developer-
 
 #### Usage
 
-Initialize the client with a username and password.  This user *must* have Admin privs::
+Initialize the client with a username and password or token and user_id.
+This user *must* have Admin privs:
 
     from rocketchat.api import RocketChatAPI
 
     api = RocketChatAPI(settings={'username': 'someuser', 'password': 'somepassword',
+                                  'domain': 'https://myrockethchatdomain.com'})
+    # or
+    api = RocketChatAPI(settings={'token': 'sometoken', 'user_id': 'someuserid',
                                   'domain': 'https://myrockethchatdomain.com'})
 
 ##### Available Calls

--- a/rocketchat/calls/base.py
+++ b/rocketchat/calls/base.py
@@ -23,6 +23,11 @@ class RocketChatBase(object):
         self.set_auth_headers()
 
     def set_auth_token(self):
+        if self.settings.get('token') and self.settings.get('user_id'):
+            self.auth_token = self.settings.get('token')
+            self.auth_user_id = self.settings.get('user_id')
+            return
+
         url = '{domain}/api/v1/login'.format(
             domain=self.settings['domain']
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@ import unittest
 import mock
 
 from rocketchat.api import RocketChatAPI
+from rocketchat.calls.base import RocketChatBase
 from rocketchat.calls.chat.send_message import SendMessage
 
 
@@ -26,6 +27,17 @@ class APITestCase(object):
                          'password': 'something',
                          'domain': 'https://www.example.com'}
         self.api = RocketChatAPI(settings=self.settings)
+
+
+class TokenAuthTestCase(unittest.TestCase):
+    def test_token_auth_params(self):
+        settings = {'token': 'some_token',
+                    'user_id': 'some_id',
+                    'domain': 'https://www.example.com'}
+        api = RocketChatAPI(settings=settings)
+        base = RocketChatBase(settings=api.settings)
+        self.assertEqual(base.headers['X-Auth-Token'], 'some_token')
+        self.assertEqual(base.headers['X-User-Id'], 'some_id')
 
 
 class SendMessageTestCase(APITestCase, unittest.TestCase):


### PR DESCRIPTION
Fixes #27 

Also it avoids the error `429 Too Many Requests`, because with username and password the lib reauthenticates for every request