### PR TITLE
stop invalidating access token after each request

### DIFF
--- a/rocketchat/calls/base.py
+++ b/rocketchat/calls/base.py
@@ -45,12 +45,6 @@ class RocketChatBase(object):
         self.headers['X-Auth-Token'] = self.auth_token
         self.headers['X-User-Id'] = self.auth_user_id
 
-    def logoff(self):
-        url = '{domain}/api/v1/logout'.format(
-            domain=self.settings['domain']
-        )
-        requests.get(url, headers=self.headers)
-
     def post_response(self, result):
         return result
 
@@ -115,7 +109,6 @@ class RocketChatBase(object):
         ))
 
         result.raise_for_status()
-        self.logoff()
 
         try:
             logger.debug('API Response - {data}'.format(


### PR DESCRIPTION
This is my first attempt to fix #50 - minimal change fixing the issue and not breaking any tests.

I don't expect it to make it in master as is (most probably there's some reason for the call to `logoff()`), but I hope to get some feedback why the call to `logoff()` is useful and prepare a less naive solution subsequently.