### PR TITLE
Fix logoff, when using token auth

### DIFF
--- a/rocketchat/calls/base.py
+++ b/rocketchat/calls/base.py
@@ -46,6 +46,9 @@ class RocketChatBase(object):
         self.headers['X-User-Id'] = self.auth_user_id
 
     def logoff(self):
+        if self.settings.get('token'):
+            return None
+
         url = '{domain}/api/v1/logout'.format(
             domain=self.settings['domain']
         )


### PR DESCRIPTION
Hello

This is a small fix for a bug due to which authorization by token was one-time.
When we use `settings={'token': 'sometoken' ...` and the `/api/v1/logout` method is called in the code, then this token is removed from the server and is no longer valid.