### PR TITLE
Fix traceback: user['emails'] may be unset

### DIFF
--- a/rocketchat/calls/users/get_users.py
+++ b/rocketchat/calls/users/get_users.py
@@ -21,7 +21,7 @@ class GetUsers(RocketChatBase):
             for user in _users:
                 user_dict = dict()
                 user_dict['name'] = user.get('name')
-                user_dict['emails'] = [email['address'] for email in user.get('emails')]
+                user_dict['emails'] = [email['address'] for email in user.get('emails', [])]
                 user_dict['username'] = user.get('username')
                 user_dict['type'] = user.get('type')
                 user_dict['status'] = user.get('status')


### PR DESCRIPTION
Exception in fetching public rooms 'NoneType' object is not iterable
Traceback (most recent call last):
  File "/home/example/git/rocketchat/venv/lib/python3.7/site-packages/rocketchat/calls/users/get_users.py", line 24, in post_response
    user_dict['emails'] = [email['address'] for email in user.get('emails')]
TypeError: 'NoneType' object is not iterable

Solution: add an empty list as default value for `user.get('emails')`